### PR TITLE
Methods that allow to access attributes in namespaces

### DIFF
--- a/parametric.py
+++ b/parametric.py
@@ -27,6 +27,10 @@ class SvgObject(object):
     This class is a wrapper of the svg node, attributes are mapped
     to lxml node attributes
     """
+    prefixes = {
+        "sodipodi":"{http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd}",
+        "inkscape":"{http://www.inkscape.org/namespaces/inkscape}",
+    }
     def __init__(self, lxml):
         object.__setattr__(self, 'e', lxml)
 
@@ -38,6 +42,19 @@ class SvgObject(object):
 
     def __setattr__(self, name, value):
         self.e.attrib[name] = str(value)
+
+    def attrname(self, name):
+        splitted_name = name.split(':')
+        if (len(splitted_name) > 0):
+            if splitted_name[0] in self.prefixes:
+                return self.prefixes[splitted_name[0]] + splitted_name[1]
+        return name
+
+    def getattr(self, name):
+        return self.e.attrib[self.attrname(name)]
+
+    def setattr(self, name, value):
+        self.e.attrib[self.attrname(name)] = str(value)
 
     def isgroup(self):
         return self.getE().tag == 'g'


### PR DESCRIPTION
I found your tool yesterday. I was very happy to know, that it exist, in spite of inkscape limitations. Playing around and getting to know the tool, I stuck with an issue. How to work with attributes that have ':' in name. Like sodipodi:sides for number of sides in the star. I can't do it like this:
```
star.sodipodi:sides
```
as it will be syntax error.

I tried like this:
```
star.__getattr__('sodipodi:sides')
```
and it didn't work, as the full attribute name has to be:
```
'{http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd}sides'
```
Which is ugly as hall.

I am not that good at codding and python, and don't like, that I used hard-code, but the solution that I found is working, and might help someone else
