### PR TITLE
Inkscape-1.0/Python 3 Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ See: example2.svg
 ## Install
 
 Just copy parametric.py and parametric.inx to your inkscape extensions folder.
+The exact location will vary depending on your inkscape installation and settings.
+From within inkscape select Preferences... under the Edit menu and then select System
+to see where the extensions folder is on your system.
 
 After install, restart inkscape and the extension will appear:
 

--- a/parametric.inx
+++ b/parametric.inx
@@ -20,14 +20,13 @@
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
     <_name>Run and Update</_name>
     <id>com.fdmtech.inkscape.parametric</id>
-    <dependency type="executable" location="extensions">parametric.py</dependency>
-    <dependency type="executable" location="extensions">inkex.py</dependency>
+    <dependency type="executable" location="inx">parametric.py</dependency>
     <effect>
       <effects-menu>
         <submenu _name="Parametric SVG"/>
       </effects-menu>
     </effect>
     <script>
-        <command reldir="extensions" interpreter="python">parametric.py</command>
+        <command location="inx" interpreter="python">parametric.py</command>
     </script>
 </inkscape-extension>

--- a/parametric.py
+++ b/parametric.py
@@ -18,7 +18,7 @@
     along with inkscape-parametric.  If not, see <https://www.gnu.org/licenses/>.
 '''
 import inkex, simplestyle, simplepath, math, copy, sys
-from StringIO import StringIO
+from io import StringIO
 
 etree = inkex.etree
 
@@ -68,7 +68,7 @@ class SvgDoc(object):
         else:
             return SvgObject(node)
 
-class Parametric(inkex.Effect):
+class Parametric(inkex.EffectExtension):
     """
     This extension adds parametric functionality to the svg document.
      1 - Any python code inside <parametric:script></parametric:script> will be
@@ -120,17 +120,17 @@ class Parametric(inkex.Effect):
         reparsed = False
         try:
             # Parse already parametric svg document
-            self.document = inkex.etree.parse(StringIO(data), parser=p)
+            self.document = inkex.etree.parse(io.StringIO(data), parser=p)
         except:
             # Parse not parametric svg document with 'invalid' parametric attributes
             reparsed = True
             data = self.add_parametric(data)
-            self.document = inkex.etree.parse(StringIO(data), parser=p)
+            self.document = inkex.etree.parse(io.StringIO(data), parser=p)
 
         # Parse non parametric svg document
         if not self.isparametric() and not reparsed:
             data = self.add_parametric(data)
-            self.document = inkex.etree.parse(StringIO(data), parser=p)
+            self.document = inkex.etree.parse(io.StringIO(data), parser=p)
 
         # Add parametric script if not exists
         root = self.getroot()
@@ -190,7 +190,7 @@ class Parametric(inkex.Effect):
 
 if __name__ == '__main__':
     e = Parametric()
-    e.affect()
+    e.run()
 
 
 # vim: expandtab shiftwidth=4 tabstop=4 softtabstop=4 fileencoding=utf-8 textwidth=99

--- a/parametric_editor.inx
+++ b/parametric_editor.inx
@@ -20,15 +20,14 @@
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
     <_name>External code editor</_name>
     <id>com.fdmtech.inkscape.parametric_editor</id>
-    <dependency type="executable" location="extensions">parametric_editor.py</dependency>
-    <dependency type="executable" location="extensions">parametric.py</dependency>
-    <dependency type="executable" location="extensions">inkex.py</dependency>
+    <dependency type="executable" location="inx">parametric_editor.py</dependency>
+    <dependency type="executable" location="inx">parametric.py</dependency>
     <effect>
       <effects-menu>
         <submenu _name="Parametric SVG"/>
       </effects-menu>
     </effect>
     <script>
-        <command reldir="extensions" interpreter="python">parametric_editor.py</command>
+        <command location="inx" interpreter="python">parametric_editor.py</command>
     </script>
 </inkscape-extension>

--- a/parametric_editor.py
+++ b/parametric_editor.py
@@ -18,7 +18,6 @@
     along with inkscape-parametric.  If not, see <https://www.gnu.org/licenses/>.    
 '''
 import inkex, simplestyle, simplepath, math, copy, sys, subprocess, tempfile, os
-from StringIO import StringIO
 import parametric
 
 class ParametricEditor(parametric.Parametric):
@@ -37,11 +36,15 @@ class ParametricEditor(parametric.Parametric):
                 code = '""" Write Python code Here """'
             else:
                 code = script.text
-            codeFile = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+            codeFile = tempfile.NamedTemporaryFile(mode="w+", suffix=".py", delete=False)
             codeFile.write(code)
             codeFileName = codeFile.name
             codeFile.close()
+            # if you have troubles on your windows system, you can comment out the SciTE line
+            # and uncomment the notepad.exe line.  If this works and launches notepad then
+            # it is likely an issue with SciTE not being in the system PATH.
             subprocess.call(['SciTE', codeFileName])
+            #subprocess.call(['notepad.exe', codeFileName])
             codeStream = open(codeFileName, 'r')
             code = codeStream.read()
             codeStream.close()
@@ -54,7 +57,7 @@ class ParametricEditor(parametric.Parametric):
 
 if __name__ == '__main__':
     e = ParametricEditor()
-    e.affect()
+    e.run()
 
 
 # vim: expandtab shiftwidth=4 tabstop=4 softtabstop=4 fileencoding=utf-8 textwidth=99


### PR DESCRIPTION
These are the changes I needed to get this useful utility working with the Inkscape-1.0 release.  Tested under a windows machine.  Hope this helps and is useful. 

I noted that [https://inkscape.org/~mnesarco/%E2%98%85parametric-svg](url) warned that the previous release may not work with Inkscape-1.0 and indeed that is what I found after updating from the 0.9 series.